### PR TITLE
Add triage task

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,20 @@ inputs:
   email_token:
     description: Email github_token
     required: true
+  patchwork_token:
+    description: Patchwork access token
+    required: true
+  task:
+    description: The name of the task to run.
+    required: false
+    default: 'status'
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
+args:
+  - ${{ inputs.task }}
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     EMAIL_TOKEN: ${{ inputs.email_token }}
+    PATCHWORK_TOKEN: ${{ inputs.patchwork_token }}

--- a/config.ini
+++ b/config.ini
@@ -20,7 +20,7 @@ starttls = yes
 default-to = linux-bluetooth@vger.kernel.org
 ; List of maintainsers
 maintainers = marcel@holtmann.org,
-              luiz.dentz@gmail.com,
+              luiz.von.dentz@intel.com,
               brian.gix@intel.com,
               inga.stotland@intel.com,
               tedd.an@intel.com
@@ -29,4 +29,3 @@ maintainers = marcel@holtmann.org,
 ; If this is option is 'yes', email will be sent only to the maintainers and
 ; the address in default-to will not be used. Default is 'no'
 only-maintainers = yes
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ echo "REF: $GITHUB_REF"
 echo "HEAD-REF: $GITHUB_HEAD_REF"
 echo "BASE-REF: $GITHUB_BASE_REF"
 echo "PWD: $(pwd)"
+echo "Param #1": $1
 
 if [[ -z $GITHUB_TOKEN ]]
 then
@@ -19,4 +20,4 @@ then
 	exit 1
 fi
 
-/pw-status.py -v
+/pw-status.py -v $1


### PR DESCRIPTION
This patch adds new task for triaging the patches in the patchwork.
If the patches older than 3 days are still in New state, it changes them
to Queued state and send email to the maintainers.

This should run daily.