### PR TITLE
pw-status: triage: check commenter from the patch

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -29,3 +29,17 @@ maintainers = marcel@holtmann.org,
 ; If this is option is 'yes', email will be sent only to the maintainers and
 ; the address in default-to will not be used. Default is 'no'
 only-maintainers = yes
+
+;
+; Triage options
+;
+[triage]
+; List of reviewer's email. It is used to filter out the patches already
+; replied by the maintainers
+reviewers = marcel@holtmann.org,
+            luiz.von.dentz@intel.com,
+            luiz.dentz@gmail.com,
+            brian.gix@intel.com,
+            inga.stotland@intel.com,
+            tedd.an@intel.com,
+            tedd.an@linux.intel.com


### PR DESCRIPTION
This patch si for triage option to check the commenter name and compare
it with the reviewer list defined in the config.ini and skip notifying
the series if any of the reviewers sent the comment for the patches.